### PR TITLE
Design document for keyboard handler

### DIFF
--- a/docs/design/keyboard_handler.md
+++ b/docs/design/keyboard_handler.md
@@ -60,7 +60,8 @@ not better than C or C++ for this case. And here is the rational for that:
    enough and have low quality.
 2. Most of the ROS2 code written in C++ and it will be much easy to support and use solution
    written on the same language.
-3. Some of the POSIX compatible OSes doesn't have Python interpreter. For instance [QNX for safety](https://blackberry.qnx.com/en/software-solutions/embedded-software/qnx-os-for-safety) 
+3. Some of the POSIX compatible OSes doesn't have Python interpreter. For instance 
+   [QNX for safety](https://blackberry.qnx.com/en/software-solutions/embedded-software/qnx-os-for-safety) 
 
 ## Specific of handling input from keyboard on different platforms
 Processing of the keyboard handling is differ for different operating systems.
@@ -68,7 +69,7 @@ There are two major different approaches:
 1. Unix/MacOS aka POSIX "compatible" OSes
 2. Windows family OSes
 
-Posix compatible OSes approach based on readout from standard input linked to the terminal.
+POSIX compatible OSes approach based on readout from standard input linked to the terminal.
 Pressed key combination represented as sequence of 8 bit values. Number of the 8 bit values in sequence
 could vary from pressed key combination and usually in range of 1-8 chars. Note: There are no
 '\0' value representing null terminator in providing sequence of bytes. i.e. those byte
@@ -82,6 +83,27 @@ integer values. Simple alphanumerical keys represented as single integer. Contro
 function keys represented as two integer values. Note: for some key combinations first integer 
 value could contain '\0' value representing null terminator in regular strings. 
 i.e it is not possible to treat such sequence of bytes as regular strings.
+
+###Specific of handling input from keyboard on POSIX compatible platforms
+POSIX systems support two basic modes of input: canonical and noncanonical. In canonical input 
+processing mode, terminal input is processed in lines terminated by newline '\n', EOF, or 
+EOL characters. No input can be read until an entire line has been typed by the user. Most 
+programs use canonical input mode, because this gives the user a way to edit input line by line 
+and this is what many of users accustom to see when typing commands in terminal window. \
+However to be able to handle single key press, terminal input need to be switched to the 
+noncanonical mode. By design keyboard handler will switch current terminal session to the 
+noncanonical mode during construction and return it to the canonical mode in destructor.
+
+##Handling abnormal program termination via Ctrl+C
+By design keyboard handler not providing ability to transfer `Ctrl+C` key press event to its 
+clients via callbacks. It could be considered as current design limitation.  
+On POSIX compatible platforms when user pressing `Ctrl+C` OS generates specific `SIGINT` signal 
+and if this signal became unhandled current process will be terminated. \
+On POSIX compatible platforms keyboard handler will register it's own signal handler for the 
+`SIGINT` to be able to return terminal input in canonical mode after abnormal program termination 
+via pressing `Ctrl+C`. This signal handling could overlap with registered specific `SIGINT` 
+handler on upper level or inside keyboard handler's clients. It could cause side effects and 
+considering as current design and implementation limitations. 
 
 ## Handling cases when client's code subscribed to the key press event got destructed before keyboard handler.
 There are two options to properly handle this case:
@@ -132,6 +154,7 @@ There are two options to properly handle this case:
         void callback_func(KeyboardHandler::KeyCode key_code);
       }
       ```
+      
    2. Using [`shared_from_this()`](https://en.cppreference.com/w/cpp/memory/enable_shared_from_this/enable_shared_from_this). 
       Note in this case client class should be inherited from 
       [`std::enable_shared_from_this`](https://en.cppreference.com/w/cpp/memory/enable_shared_from_this/enable_shared_from_this) 
@@ -155,10 +178,10 @@ There are two options to properly handle this case:
           keyboard_handler.add_key_press_callback(callback, KeyboardHandler::KeyCode::CURSOR_UP);
         }
       ```
+      
       `Player` class could be instantiated as 
       `std::shared_ptr<Player> player_shared_ptr(new Player());`
-   
-   
+      
 ## Handling cases when standard input from terminal or console redirected to the file or stream.
 By design keyboard handler rely on the assumption that it will poll on keypress event and then 
 readout pressed keys from standard input. When standard input redirected to be read from the 
@@ -186,6 +209,7 @@ skipped during unit test. For instance:
     // Handle exceptions
   }
 ```
+
 As you can see it will be impossible to separate exception handling for the case if keyboard 
 handler will throw exception when it's running under the `gtest`.
 

--- a/docs/design/keyboard_handler.md
+++ b/docs/design/keyboard_handler.md
@@ -1,0 +1,87 @@
+# Keyboard handler
+Package providing ability to handle keyboard input via simple interface with callbacks. 
+
+## Goal
+We need to be able to handle keyboard input in unified way with cross-platform implementation.
+
+## Design Proposal
+It would be great to have some simple interface to be able to subscribe to the specific key 
+press event using callbacks. Also it would useful to have ability to handle events for 
+combination of keys pressed in one callback as well as have possibility to subscribe to the 
+same event from multiple clients.
+
+The following pseudocode suggests the high level API for aforementioned design proposal.
+```cpp
+    ClientClass1 client1;
+    ClientClass2 client2;
+    KeyboardHandler keyboard_handler;
+    client1.register_key_press_callbacks(keyboard_handler);
+    client2.register_callbacks_for_keyboard_handler(keyboard_handler);
+```
+Inside client class registering for the callbacks could be organized as simple as:
+```cpp
+  ClientClass1::register_key_press_callbacks(KeyboardHandler & keyboard_handler) 
+  {
+    keyboard_handler.add_key_press_callback(callback_fn, KeyboardHandler::KeyCode::CURSOR_UP);
+    keyboard_handler.add_key_press_callback(callback_fn, KeyboardHandler::KeyCode::SHIFT_F1);
+  }
+```
+To be able to handle multiple events in one callback function and have ability to distinguish 
+them inside, this callback function should have input parameter indicating which key combination 
+handling in the current call. For instance it could be implemented as simple as:
+```cpp
+  void callback_function(KeyboardHandler::KeyCode key_code)
+  {
+    using KeyCode = KeyboardHandler::KeyCode;
+    switch (key_code) {
+      case KeyCode::CURSOR_UP:
+        std::cout << "callback with key code = CURSOR_UP" << std::endl;
+      break;
+      case KeyCode::SHIFT_F1:
+        std::cout << "callback for pressed key combination = Shift + F1" << std::endl;
+      break;
+      default:
+       std::cout << "callback with key code = " << static_cast<int32_t>(key_code) << std::endl;
+      break;
+    }
+  }
+```
+
+## Consideration of using C++ versus Python for cross-platform implementation
+At the very early design discussions was proposed to use Python as cross-platform 
+implementation for keyboard handling. From the first glance it looks attractive to use Python 
+since it's relatively new language with reach built-in utility functions available on multiple 
+platforms and OSes.
+However after some research and consideration we come to the conclusion that using Python is 
+not better than C or C++ for this case. And here is the rational for that:
+1. It turns out that there are no built-in and cross-platform utility functions for handling input 
+   from keyboard in Python. All what you can find is a third party libraries with similar 
+   compile time division for Windows and Unix platforms. Most of the libraries not mature 
+   enough and have low quality.
+2. Most of the ROS2 code written in C++ and it will be much easy to support and use solution
+   written on the same language.
+3. Some of the POSIX compatible OSes doesn't have Python interpreter. For instance [QNX for safety](https://blackberry.qnx.com/en/software-solutions/embedded-software/qnx-os-for-safety) 
+
+## Specific of handling input from keyboard on different platforms
+Processing of the keyboard handling is differ for different operating systems.
+There are two major different approaches:
+1. Unix/MacOS aka POSIX "compatible" OSes
+2. Windows family OSes
+
+Posix compatible OSes approach based on readout from standard input linked to the terminal.
+Pressed key combination represented as sequence of 8 bit values. Number of the 8 bit values in sequence
+could vary from pressed key combination and usually in range of 1-8 chars. Note: There are no
+'\0' value representing null terminator in providing sequence of bytes. i.e. those byte
+sequence could be treated as "C" strings if add null terminator at the end.
+
+In Windows family OSes available mechanism for keyboard handling derived from DOS which is based on
+polling "`int kbhit()`" system function call until it will return non zero value indicating that
+some key was pressed. After that need to read integer value(s) from the standard input to
+determine which key was pressed. Pressed key combinations could be represented as one or two 
+integer values. Simple alphanumerical keys represented as single integer. Control keys and specific
+function keys represented as two integer values. Note: for some key combinations first integer 
+value could contain '\0' value representing null terminator in regular strings. 
+i.e it is not possible to treat such sequence of bytes as regular strings.
+
+## Considerations of how to handle cases when client code subscribed to the key press event got destructed before keyboard handler.
+TBD.

--- a/docs/design/keyboard_handler.md
+++ b/docs/design/keyboard_handler.md
@@ -4,12 +4,12 @@ Package providing ability to handle keyboard input via simple interface with cal
 ## Goal
 We need to be able to handle keyboard input in unified way with cross-platform implementation.
 
-## Design Proposal
-It would be great to have some simple interface to be able to subscribe to the specific key 
-press event using callbacks. Also it would useful to have ability to handle events for 
-combination of keys pressed in one callback as well as have possibility to subscribe to the 
-same event from multiple clients.
+##Design requirements:
+* Subscribe to keyboard events via callbacks
+* Subscriptions work with key modifiers (e.g. Shift+F1)
+* Multiple clients can subscribe to the same event
 
+## Design Proposal
 The following pseudocode suggests the high level API for aforementioned design proposal.
 ```cpp
     ClientClass1 client1;

--- a/docs/design/keyboard_handler.md
+++ b/docs/design/keyboard_handler.md
@@ -229,4 +229,16 @@ go in to the special safe state where he will aware about this situation and key
 will be disabled.
 
 Note: By design `KeyboardHandler::add_key_press_callback(..)` API call will return `false` in 
-this case to indicate that handling keypress is not possible in this case.   
+this case to indicate that handling keypress is not possible in this case.
+
+## Known issues
+Due to the current design and implementation limitations keyboard handler has following known 
+issues:
+ - Some keys might be incorrectly detected with multiple key modifiers pressed at the same time.
+ - Keyboard handler not able to correctly detect `CTRL` + `0..9` number keys. 
+ - Instead of `CTRL` + `SHIFT` + `key` will be detected only `CTRL` + `key`.
+ - Unix(POSIX) implementation can't correctly detect `CTRL`, `ALT`, `SHIFT` modifiers with 
+   `F1..F12` and other control keys.
+ - Windows implementation not able to detect `CTRL` + `ALT` + `key` combinations.
+ - Windows implementation not able to detect `ALT` + `F1..12` keys.
+


### PR DESCRIPTION
Design document for keyboard handler package.

Relates to the [#735](https://github.com/ros2/rosbag2/pull/735)
Part of the [#696](https://github.com/ros2/rosbag2/issues/696)

Moved content from https://github.com/ros2/rosbag2/pull/768.
Also updated API with key modifiers in callbacks and added new section with known issues and design/implementation limitations. 