### PR TITLE
Force exit from main thread on signal handling in `keyboard_handler`

### DIFF
--- a/keyboard_handler/include/keyboard_handler/keyboard_handler_unix_impl.hpp
+++ b/keyboard_handler/include/keyboard_handler/keyboard_handler_unix_impl.hpp
@@ -109,13 +109,15 @@ protected:
   static const size_t STATIC_KEY_MAP_LENGTH;
 
 private:
+  static void on_signal(int signal_number);
+
   static struct termios old_term_settings_;
   static tcsetattrFunction tcsetattr_fn_;
   static signal_handler_type old_sigint_handler_;
   bool install_signal_handler_ = false;
 
   std::thread key_handler_thread_;
-  std::atomic_bool exit_;
+  static std::atomic_bool exit_;
   const int stdin_fd_;
   std::unordered_map<std::string, KeyCode> key_codes_map_;
   std::exception_ptr thread_exception_ptr{nullptr};


### PR DESCRIPTION
- Relates [ros2 bag record and play does occasionally not properly closing when pressing Ctrl+C rosbag2#1079](https://github.com/ros2/rosbag2/issues/1079)

Trigger internal exit variable to true from signal handler in keyboard handler to avoid getting stuck on next read function after changing input mode to the canonical i.e. required to press `Enter`.