### PR TITLE
Fix for `No definition of [ament_cmake] for OS version [focal]`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
     - uses: ros-tooling/action-ros-ci@v0.2
       with:


### PR DESCRIPTION
Fix for CI build failure according to the discussion and proposed solution from https://github.com/ros-tooling/keyboard_handler/pull/23#issuecomment-1240659385

Changed target to ubuntu-jammy in CI actions
