### PR TITLE
0.1.0 for rolling

### DIFF
--- a/keyboard_handler/CHANGELOG.rst
+++ b/keyboard_handler/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package keyboard_handler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Force exit from main thread on signal handling in `keyboard_handler` (`#23 <https://github.com/ros-tooling/keyboard_handler/issues/23>`_)
+* Contributors: Michael Orlov
+
 0.0.4 (2022-03-29)
 ------------------
 * Install includes to include/${PROJECT_NAME} and misc CMake fixes (`#12 <https://github.com/ros-tooling/keyboard_handler/issues/12>`_)

--- a/keyboard_handler/CHANGELOG.rst
+++ b/keyboard_handler/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package keyboard_handler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.0 (2022-11-08)
+------------------
 * Force exit from main thread on signal handling in `keyboard_handler` (`#23 <https://github.com/ros-tooling/keyboard_handler/issues/23>`_)
 * Contributors: Michael Orlov
 

--- a/keyboard_handler/package.xml
+++ b/keyboard_handler/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>keyboard_handler</name>
-  <version>0.0.4</version>
+  <version>0.1.0</version>
   <description>Handler for input from keyboard</description>
   <maintainer email="michael.orlov@apex.ai">michael</maintainer>
   <maintainer email="karsten@openrobotics.org">Karsten Knese</maintainer>


### PR DESCRIPTION
This is just to leave room in the numbering scheme for humble (which will now always be 0.0.x).  Rolling can move forward as needed.

@MichaelOrlov FYI.