### PR TITLE
Fixed C++20 warning implicit capture of this in lambda

### DIFF
--- a/keyboard_handler/src/keyboard_handler_unix_impl.cpp
+++ b/keyboard_handler/src/keyboard_handler_unix_impl.cpp
@@ -181,7 +181,7 @@ KeyboardHandlerUnixImpl::KeyboardHandlerUnixImpl(
   is_init_succeed_ = true;
 
   key_handler_thread_ = std::thread(
-    [ = ]() {
+    [this, read_fn] {
       try {
         static constexpr size_t BUFF_LEN = 10;
         char buff[BUFF_LEN] = {0};


### PR DESCRIPTION
Fixes a warning issued by C++20 for the implicit capture of ```this``` when using ```[ = ]```. Since ```[=, this]``` is not available yet in C++17 I just explicitly capture the ```this``` pointer and any other variables by copy.
