### PR TITLE
Shorten lambdas so newer uncrustify is happier.

### DIFF
--- a/keyboard_handler/test/fake_player.hpp
+++ b/keyboard_handler/test/fake_player.hpp
@@ -27,10 +27,10 @@ public:
 
   void register_callbacks(KeyboardHandler & keyboard_handler)
   {
-    std::weak_ptr<FakePlayer> player_weak_ptr(shared_from_this());
-    auto callback = [player_weak_ptr](KeyboardHandler::KeyCode key_code,
-        KeyboardHandler::KeyModifiers key_modifiers) {
-        auto player_shared_ptr = player_weak_ptr.lock();
+    std::weak_ptr<FakePlayer> weak_ptr(shared_from_this());
+    auto callback =
+      [weak_ptr](KeyboardHandler::KeyCode key_code, KeyboardHandler::KeyModifiers key_modifiers) {
+        auto player_shared_ptr = weak_ptr.lock();
         if (player_shared_ptr) {
           player_shared_ptr->callback_func(key_code, key_modifiers);
         } else {

--- a/keyboard_handler/test/fake_recorder.hpp
+++ b/keyboard_handler/test/fake_recorder.hpp
@@ -36,11 +36,11 @@ public:
 
   void register_callbacks(KeyboardHandler & keyboard_handler)
   {
-    auto callback = [recorder_weak_ptr = weak_self_](KeyboardHandler::KeyCode key_code,
-        KeyboardHandler::KeyModifiers key_modifiers) {
-        auto recorder_shared_ptr = recorder_weak_ptr.lock();
+    auto callback =
+      [weak_ptr = weak_self_](KeyboardHandler::KeyCode code, KeyboardHandler::KeyModifiers mods) {
+        auto recorder_shared_ptr = weak_ptr.lock();
         if (recorder_shared_ptr) {
-          recorder_shared_ptr->callback_func(key_code, key_modifiers);
+          recorder_shared_ptr->callback_func(code, mods);
         } else {
           std::cout << "Object for assigned callback FakeRecorder() was deleted" << std::endl;
         }

--- a/keyboard_handler/test/keyboard_handler_unix_tests.cpp
+++ b/keyboard_handler/test/keyboard_handler_unix_tests.cpp
@@ -214,8 +214,8 @@ TEST_F(KeyboardHandlerUnixTest, unregister_callback) {
   const std::string terminal_seq =
     keyboard_handler.get_terminal_sequence(KeyboardHandler::KeyCode::E);
 
-  auto lambda_as_callback = [](KeyboardHandler::KeyCode key_code,
-      KeyboardHandler::KeyModifiers key_modifiers) {
+  auto lambda_as_callback =
+    [](KeyboardHandler::KeyCode key_code, KeyboardHandler::KeyModifiers key_modifiers) {
       ASSERT_FALSE(true) << "This code should not be called \n";
     };
   auto callback_handle = keyboard_handler.add_key_press_callback(
@@ -238,8 +238,8 @@ TEST_F(KeyboardHandlerUnixTest, stdin_is_not_a_terminal_device) {
   MockKeyboardHandler keyboard_handler(read_fn_, isatty_fail);
   ASSERT_EQ(keyboard_handler.get_number_of_registered_callbacks(), 0U);
 
-  auto callback = [](KeyboardHandler::KeyCode key_code,
-      KeyboardHandler::KeyModifiers key_modifiers) {
+  auto callback =
+    [](KeyboardHandler::KeyCode key_code, KeyboardHandler::KeyModifiers key_modifiers) {
       ASSERT_FALSE(true) << "This code should not be called \n";
     };
   auto callback_handle = keyboard_handler.add_key_press_callback(

--- a/keyboard_handler/test/keyboard_handler_windows_tests.cpp
+++ b/keyboard_handler/test/keyboard_handler_windows_tests.cpp
@@ -202,8 +202,8 @@ TEST_F(KeyboardHandlerWindowsTest, nullptr_as_callback) {
 TEST_F(KeyboardHandlerWindowsTest, unregister_callback) {
   EXPECT_CALL(*g_system_calls_stub, getch()).WillRepeatedly(Return('e'));
   MockKeyboardHandler keyboard_handler;
-  auto lambda_as_callback = [](KeyboardHandler::KeyCode key_code,
-      KeyboardHandler::KeyModifiers key_modifiers) {
+  auto lambda_as_callback =
+    [](KeyboardHandler::KeyCode key_code, KeyboardHandler::KeyModifiers key_modifiers) {
       ASSERT_FALSE(true) << "This code should not be called \n";
     };
   auto callback_handle = keyboard_handler.add_key_press_callback(
@@ -225,8 +225,8 @@ TEST_F(KeyboardHandlerWindowsTest, stdin_is_not_a_terminal_device) {
   MockKeyboardHandler keyboard_handler(isatty_fail);
   ASSERT_EQ(keyboard_handler.get_number_of_registered_callbacks(), 0U);
 
-  auto callback = [](KeyboardHandler::KeyCode key_code,
-      KeyboardHandler::KeyModifiers key_modifiers) {
+  auto callback =
+    [](KeyboardHandler::KeyCode key_code, KeyboardHandler::KeyModifiers key_modifiers) {
       ASSERT_FALSE(true) << "This code should not be called \n";
     };
   auto callback_handle = keyboard_handler.add_key_press_callback(


### PR DESCRIPTION
This also keeps compatibility with existing uncrustify. No functional change.