### PR TITLE
Name the linter CI job properly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ament_linters:
-    name: ament_copyright
+    name: ament_${{ linter }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
It was called `ament_copyright` for all of them before