### PR TITLE
Use the latest version of Docker image in actions instead of master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-noble:master
+      image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-noble:latest
     steps:
     - uses: ros-tooling/action-ros-ci@v0.4
       with:


### PR DESCRIPTION
- Use the latest version of Docker image in actions instead of master

Rationale: It seems the master Docker image hasn't been rebuilt since the apt repo GPG key was changed.